### PR TITLE
Track loot sent directly to the bank from Lunar Chests

### DIFF
--- a/src/main/java/com/gpperhour/GPPerHourPlugin.java
+++ b/src/main/java/com/gpperhour/GPPerHourPlugin.java
@@ -72,6 +72,7 @@ import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.client.callback.ClientThread;
@@ -216,7 +217,6 @@ public class GPPerHourPlugin extends Plugin
 	private Widget inventoryWidget;
 	private ItemContainer inventoryItemContainer;
 	private ItemContainer equipmentItemContainer;
-	private ItemContainer rewardsItemContainer;
 	private boolean postNewRun = false;
 	private long newRunTick = 0;
 	private boolean expectingPutAnimation = false;
@@ -608,7 +608,7 @@ public class GPPerHourPlugin extends Plugin
 	{
 		if (event.getGroupId() == InterfaceID.KINGDOM)
 		{
-			rewardsItemContainer = client.getItemContainer(InventoryID.KINGDOM_OF_MISCELLANIA);
+			ItemContainer rewardsItemContainer = client.getItemContainer(InventoryID.KINGDOM_OF_MISCELLANIA);
 			if (rewardsItemContainer != null)
 			{
 				refreshQtyMap(rewardsQtyMap, rewardsItemContainer);
@@ -635,18 +635,49 @@ public class GPPerHourPlugin extends Plugin
 			depositInteractionTick = client.getTickCount();
 		}
 
-		// Lunar Chest "Bank-all" button
-		// MenuOptionClicked(getParam0=-1, getParam1=56885268, getMenuOption=Bank-all, getMenuTarget=, getMenuAction=CC_OP, getId=1)
-		if (event.getParam1() == 56885268 && "Bank-all".equals(event.getMenuOption()) && event.getMenuAction() == MenuAction.CC_OP)
+		if ("Bank-all".equals(event.getMenuOption()))
 		{
-			rewardsItemContainer = client.getItemContainer(InventoryID.LUNAR_CHEST);
-			if (rewardsItemContainer != null) {
-				refreshQtyMap(rewardsQtyMap, rewardsItemContainer);
-				for (int itemId: rewardsQtyMap.keySet()) {
-					runData.bankedItemQtys.merge(itemId, rewardsQtyMap.get(itemId), Float::sum);
+			InventoryID inventory = null;
+			switch (WidgetUtil.componentToInterface(event.getParam1()))
+			{
+				case InterfaceID.CHAMBERS_OF_XERIC_REWARD:
+					inventory = InventoryID.CHAMBERS_OF_XERIC_CHEST;
+					break;
+				case InterfaceID.DRIFT_NET_FISHING_REWARD:
+					inventory = InventoryID.DRIFT_NET_FISHING_REWARD;
+					break;
+				case InterfaceID.FORTIS_COLOSSEUM_REWARD:
+					inventory = InventoryID.FORTIS_COLOSSEUM_REWARD_CHEST;
+					break;
+				case InterfaceID.LUNAR_CHEST:
+					inventory = InventoryID.LUNAR_CHEST;
+					break;
+				case InterfaceID.TOA_REWARD:
+					inventory = InventoryID.TOA_REWARD_CHEST;
+					break;
+				case InterfaceID.TOB_REWARD:
+					inventory = InventoryID.THEATRE_OF_BLOOD_CHEST;
+					break;
+				case InterfaceID.TRAWLER_REWARD:
+					inventory = InventoryID.FISHING_TRAWLER_REWARD;
+					break;
+				case InterfaceID.WILDERNESS_LOOT_CHEST:
+					inventory = InventoryID.WILDERNESS_LOOT_CHEST;
+					break;
+			}
+			if (inventory != null)
+			{
+				ItemContainer rewardsItemContainer = client.getItemContainer(inventory);
+				if (rewardsItemContainer != null)
+				{
+					refreshQtyMap(rewardsQtyMap, rewardsItemContainer);
+					for (int itemId: rewardsQtyMap.keySet())
+					{
+						runData.bankedItemQtys.merge(itemId, rewardsQtyMap.get(itemId), Float::sum);
+					}
+					updatePluginState(false);
 				}
 			}
-			updatePluginState(false);
 		}
 	}
 	

--- a/src/main/java/com/gpperhour/GPPerHourPlugin.java
+++ b/src/main/java/com/gpperhour/GPPerHourPlugin.java
@@ -606,6 +606,19 @@ public class GPPerHourPlugin extends Plugin
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
+		if (event.getGroupId() == InterfaceID.KINGDOM)
+		{
+			rewardsItemContainer = client.getItemContainer(InventoryID.KINGDOM_OF_MISCELLANIA);
+			if (rewardsItemContainer != null)
+			{
+				refreshQtyMap(rewardsQtyMap, rewardsItemContainer);
+				for (int itemId: rewardsQtyMap.keySet())
+				{
+					runData.bankedItemQtys.merge(itemId, rewardsQtyMap.get(itemId), Float::sum);
+				}
+			}
+		}
+
 		updatePluginState(false);
 	}
 

--- a/src/main/java/com/gpperhour/TripData.java
+++ b/src/main/java/com/gpperhour/TripData.java
@@ -40,6 +40,7 @@ public class TripData
     boolean isPaused = false;
 
     Map<Integer, Float> initialItemQtys = new HashMap<>();
+    Map<Integer, Float> bankedItemQtys = new HashMap<>();
     transient Map<Integer, Float> itemQtys = new HashMap<>();
 
     LinkedList<String> ignoredItems = new LinkedList<>();


### PR DESCRIPTION
In the meantime before the delta refactor mentioned in #38 is completed, this patch adds tracking for the "bank-all" button on the Moons of Peril reward chest. Could be set up for ToA loot and more, but I haven't done those, so I don't know the widget IDs. @daltonpearson might be able to get them.

[Loot Tracker](https://github.com/runelite/runelite/blob/1a2913141c25290cd6b28d06f93fa7ede2c26e10/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java#L822) was the main reference I used for this, but to avoid double-counting if you send to your inventory, I needed to trigger off of the bank button instead of the popup window.