### PR TITLE
fix silklined herb sack tracking

### DIFF
--- a/src/main/java/com/gpperhour/itemcharges/items/U_HerbSack.java
+++ b/src/main/java/com/gpperhour/itemcharges/items/U_HerbSack.java
@@ -70,6 +70,8 @@ public class U_HerbSack extends ChargedItem {
         this.triggers_items = new TriggerItem[]{
                 new TriggerItem(ItemID.SLAYER_HERB_SACK),
                 new TriggerItem(ItemID.SLAYER_HERB_SACK_OPEN),
+                new TriggerItem(ItemID.SLAYER_HERB_SACK_SILK),
+                new TriggerItem(ItemID.SLAYER_HERB_SACK_SILK_OPEN)
         };
         this.triggers_chat_messages = new TriggerChatMessage[]{
                 new TriggerChatMessage("The herb sack is empty.").onItemClick().extraConsumer((message) -> super.emptyOrClear()),

--- a/src/main/java/com/gpperhour/itemcharges/items/U_HerbSack.java
+++ b/src/main/java/com/gpperhour/itemcharges/items/U_HerbSack.java
@@ -70,9 +70,13 @@ public class U_HerbSack extends ChargedItem {
         this.triggers_items = new TriggerItem[]{
                 new TriggerItem(ItemID.SLAYER_HERB_SACK),
                 new TriggerItem(ItemID.SLAYER_HERB_SACK_OPEN),
+
                 new TriggerItem(ItemID.SLAYER_HERB_SACK_SILK),
                 new TriggerItem(ItemID.SLAYER_HERB_SACK_SILK_OPEN)
         };
+
+        //Silklined sack shares all chat messages and triggers with the regular sack;
+        //the in-game text says "herb sack" for both variants.
         this.triggers_chat_messages = new TriggerChatMessage[]{
                 new TriggerChatMessage("The herb sack is empty.").onItemClick().extraConsumer((message) -> super.emptyOrClear()),
                 new TriggerChatMessage(pickupRegex).extraConsumer(message -> {
@@ -115,6 +119,13 @@ public class U_HerbSack extends ChargedItem {
                 //Empty into bank doesn't make a chat message (unless it's already empty)
                 new TriggerItemContainer(InventoryID.BANK).menuTarget("Open herb sack").menuOption("Empty to bank").extraConsumer(super::emptyOrClear),
                 new TriggerItemContainer(InventoryID.BANK).menuTarget("Herb sack").menuOption("Empty to bank").extraConsumer(super::emptyOrClear),
+
+                new TriggerItemContainer(InventoryID.INV).menuTarget("Open silklined herb sack").menuOption("Fill").addDifference(),
+                new TriggerItemContainer(InventoryID.INV).menuTarget("Silklined herb sack").menuOption("Fill").addDifference(),
+                new TriggerItemContainer(InventoryID.INV).menuTarget("Open silklined herb sack").menuOption("Empty").addDifference(),
+                new TriggerItemContainer(InventoryID.INV).menuTarget("Silklined herb sack").menuOption("Empty").addDifference(),
+                new TriggerItemContainer(InventoryID.BANK).menuTarget("Open silklined herb sack").menuOption("Empty to bank").extraConsumer(super::emptyOrClear),
+                new TriggerItemContainer(InventoryID.BANK).menuTarget("Silklined herb sack").menuOption("Empty to bank").extraConsumer(super::emptyOrClear),
         };
         //for herb sack this only works for single herbs, if dialog pops up we don't capture it. too complicated...
         this.supportsWidgetOnWidget = true;


### PR DESCRIPTION
Fixes #100.

The silklined herb sack wasn't tracked so herbs picked into it didn't count toward trip GP.

Changes (in `U_HerbSack`):
- Register `SLAYER_HERB_SACK_SILK` / `_OPEN` as trigger items.
- Add Fill / Empty / Empty-to-bank container triggers for the silklined menu targets.

The in-game chat messages are identical to the regular herb sack, so the existing chat triggers are reused as-is.

Tested:
- Ground pickup
- Use herb on sack
- Fill / Empty (open and closed)
- Check (contents and value match the sack)

Not tested: 
- Pick herb patch while farming